### PR TITLE
Restructure final project as a startup build with weekly reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Online sessions each Wednesday, 5:00pm - 8:30pm. See `SYLLABUS.md` for full asyn
 
 - **Online Lectures**: Asynchronous video content with live online sessions
 - **Hands-on Components**: Interactive Jupyter notebooks and coding exercises
-- **Final Project**: Build a startup. Teams of 3 ship a working NLP product over the full semester with weekly progress reports. See `project/guidelines.md`
+- **Final Project**: Build a startup. Teams of 3 ship a working NLP product over the full semester with weekly progress reports. See [project/guidelines.md](project/guidelines.md)
 - **Setup Verification**: Use `resources/setup_test.ipynb` to verify your environment
 
 ## Tools & Libraries Used

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Online sessions each Wednesday, 5:00pm - 8:30pm. See `SYLLABUS.md` for full asyn
 
 - **Online Lectures**: Asynchronous video content with live online sessions
 - **Hands-on Components**: Interactive Jupyter notebooks and coding exercises
-- **Final Project**: Team project with real-world NLP problem (full semester)
+- **Final Project**: Build a startup. Teams of 3 ship a working NLP product over the full semester with weekly progress reports. See `project/guidelines.md`
 - **Setup Verification**: Use `resources/setup_test.ipynb` to verify your environment
 
 ## Tools & Libraries Used

--- a/SYLLABUS.md
+++ b/SYLLABUS.md
@@ -196,7 +196,7 @@ Each week includes **asynchronous content** (videos, readings, quizzes — compl
 | **Class Participation and Engagement** | 5% | Class participation, in-class exercises, contributions |
 | **Homework Assignments** | 30% | Regular homework assignments throughout the semester |
 | **Weekly Quizzes** | 20% | Weekly quizzes to assess understanding |
-| **Final Project** | 45% | Team project (3 people; groups of 2 or 4 by special permission) |
+| **Final Project** | 45% | Build a startup: a team of 3 ships an NLP product (groups of 2 or 4 by special permission) |
 | **Total** | 100% | |
 
 ### Grade Scale
@@ -221,7 +221,7 @@ Each week includes **asynchronous content** (videos, readings, quizzes — compl
 - **Schedule**: Assignment 1 (June 10), Assignment 2 (July 8), Assignment 3 (July 29)
 - **Format**: Programming exercises and written responses
 - **Purpose**: Reinforce lecture concepts through hands-on practice
-- **Collaboration**: Individual work only — no peer collaboration (see Collaboration Policy)
+- **Collaboration**: Individual work only, no peer collaboration (see Collaboration Policy)
 
 ### Weekly Quizzes (20%)
 - **Frequency**: Weekly assessments
@@ -230,11 +230,11 @@ Each week includes **asynchronous content** (videos, readings, quizzes — compl
 - **Resources**: Notes allowed; no web, no peer collaboration
 
 ### Final Project (45%)
-- **Structure**: Team project (3 people; groups of 2 or 4 by special permission)
-- **Scope**: Realistic/real-world NLP problem
-- **Components**: Implementation + thoughtful analysis + quality writeup
-- **Timeline**: Full semester with weekly reports; presentations in Week 6 (mid-semester) and Week 12 (final)
-- **See**: project/guidelines.md for detailed requirements
+- **Structure**: Build a startup. Teams of 3 form a named company and ship a working NLP product (groups of 2 or 4 by special permission)
+- **How it works**: A weekly build, measure, learn loop with a short standup and a written report each week
+- **Grading**: Weekly reports 30%, mid-semester checkpoint in Week 6 5%, final product and demo day in Week 12 10%
+- **Timeline**: Full semester. Mid-semester demo in Week 6, demo day in Week 12
+- **See**: [project/guidelines.md](project/guidelines.md) for the full description, timeline, and rubrics
 
 ## AI Policy
 

--- a/project/guidelines.md
+++ b/project/guidelines.md
@@ -1,274 +1,189 @@
-# Final Project Guidelines
+# Final Project: Build a Startup
 
-**DATA/MSML 641: Natural Language Processing**
-**Worth**: 45% of final grade
-**Team Size**: 3 people (groups of 2 or 4 by special permission only)
-**Duration**: Full semester with weekly reports
+**DATA/MSAI/MSML 641: Natural Language Processing**
 
----
-
-## 🎯 Project Overview
-
-The final project is the capstone of this course, designed to give you hands-on experience with a substantial, realistic NLP problem. You will work in teams to implement, evaluate, and analyze an NLP system for a real-world application.
-
-### Learning Objectives
-- Apply multiple NLP techniques to solve a complex problem
-- Work with real, messy data at scale  
-- Evaluate system performance using appropriate metrics
-- Communicate technical findings to both technical and non-technical audiences
-- Collaborate effectively in a team environment
-
-## 📋 Project Scope
-
-### What Makes a Good Project
-- **Real-world relevance**: Addresses an actual problem or need
-- **Technical depth**: Requires multiple NLP techniques covered in class
-- **Appropriate scale**: Achievable in 9 weeks but non-trivial
-- **Clear evaluation**: Has measurable success criteria
-- **Data availability**: Access to sufficient, appropriate data
-
-### Suggested Project Categories
-
-1. **Information Extraction & Analysis**
-   - Social media sentiment tracking for brands/events
-   - Financial news analysis for investment insights
-   - Medical record analysis for clinical decision support
-   - Legal document analysis for case research
-
-2. **Text Generation & Summarization**
-   - Automated report generation from data
-   - News article summarization with factual accuracy
-   - Creative writing assistance tools
-   - Technical documentation generation
-
-3. **Question Answering & Search**
-   - Domain-specific Q&A systems (e.g., customer support)
-   - Semantic search for specialized corpora
-   - Chatbots for specific use cases
-   - Information retrieval from unstructured data
-
-4. **Language Understanding & Processing**
-   - Intent recognition for voice assistants
-   - Automated essay scoring
-   - Language learning assistance tools
-   - Accessibility tools (text simplification)
-
-5. **Multilingual & Cross-lingual Applications**
-   - Cross-lingual information retrieval
-   - Translation quality estimation
-   - Multilingual sentiment analysis
-   - Code-switching detection and analysis
-
-## 📅 Timeline & Deliverables
-
-### Phase 1: Project Proposal (Week 4)
-**Due**: June 24, 2026
-**Deliverable**: 2-3 page proposal
-
-**Content**:
-- Problem statement and motivation
-- Related work overview (3-5 key papers)
-- Proposed approach and techniques
-- Data sources and acquisition plan
-- Evaluation methodology and metrics
-- Team member roles and responsibilities
-- Timeline with milestones
-
-### Phase 2: Mid-Semester Presentation & Progress Report (Week 6)
-**Due**: July 8, 2026
-**Deliverable**: In-class presentation + progress report + code repository
-
-**Content**:
-- Data collection and preprocessing pipeline
-- Exploratory data analysis
-- Baseline model implementation
-- Initial results and error analysis
-- Updated project timeline
-- Challenges encountered and solutions
-
-### Phase 3: Model Development (Week 9)
-**Due**: July 29, 2026
-**Deliverable**: Technical progress report
-
-**Content**:
-- Advanced model implementations
-- Hyperparameter tuning and optimization
-- Ablation studies
-- Performance comparison with baselines
-- Error analysis and failure cases
-- Plans for final model and evaluation
-
-### Phase 4: Final Deliverables (Week 12)
-**Due**: August 19, 2026
-
-#### 4a. Technical Report (15-20 pages)
-**Structure**:
-1. **Abstract** (1 paragraph)
-2. **Introduction** (2-3 pages)
-   - Problem motivation and significance
-   - Contribution summary
-3. **Related Work** (2-3 pages)
-   - Comprehensive literature review
-   - Comparison with existing approaches
-4. **Methodology** (4-5 pages)
-   - Data collection and preprocessing
-   - Model architecture and design choices
-   - Training procedures and hyperparameters
-5. **Experiments** (3-4 pages)
-   - Experimental setup
-   - Evaluation metrics and baselines
-   - Results and statistical significance
-6. **Analysis** (2-3 pages)
-   - Error analysis and failure cases
-   - Ablation studies
-   - Computational complexity analysis
-7. **Discussion** (1-2 pages)
-   - Limitations and future work
-   - Ethical considerations
-   - Real-world deployment considerations
-8. **Conclusion** (1 page)
-9. **References** (2+ pages, 15+ papers)
-
-#### 4b. Code Repository
-**Requirements**:
-- Clean, well-documented Python code
-- README with setup and usage instructions
-- Requirements/environment files
-- Data preprocessing scripts
-- Model training and evaluation scripts
-- Reproducible results with random seeds
-- Unit tests for key functions
-
-#### 4c. Presentation (15 minutes + 5 min Q&A)
-**Structure**:
-- Problem motivation (2 min)
-- Approach overview (3 min)
-- Key results (5 min)
-- Demo/examples (3 min)
-- Conclusions and future work (2 min)
-- Q&A (5 min)
-
-**Format**: Online presentation during Week 12
-
-## 📊 Grading Rubric (100 points total)
-
-### Technical Quality (40 points)
-- **Implementation** (20 pts): Code quality, correctness, efficiency
-- **Methodology** (10 pts): Appropriate techniques, sound experimental design  
-- **Innovation** (10 pts): Novel approaches, creative solutions
-
-### Evaluation & Analysis (25 points)
-- **Experimental rigor** (15 pts): Proper baselines, metrics, statistical testing
-- **Error analysis** (10 pts): Understanding of failure cases, limitations
-
-### Communication (25 points)
-- **Written report** (15 pts): Clarity, organization, technical accuracy
-- **Oral presentation** (10 pts): Clear delivery, effective visuals
-
-### Collaboration (10 points)
-- **Team contribution** (5 pts): Equal participation, peer evaluation
-- **Project management** (5 pts): Meeting deadlines, organization
-
-### Bonus Opportunities (up to 10 extra points)
-- Deployment of working system
-- Open source contribution  
-- Novel dataset creation
-- Publication-quality analysis
-
-## 👥 Team Formation
-
-### Guidelines
-- **Size**: 3 people (groups of 2 or 4 allowed under special circumstances with instructor approval)
-- **Formation**: Self-selected by June 17, 2026 (Week 3)
-- **Skills**: Balance technical skills and domain knowledge
-- **Commitment**: Ensure all members can dedicate adequate time
-
-### Team Contract
-Each team must submit a team contract including:
-- Communication plan and meeting schedule
-- Role and responsibility assignments
-- Decision-making process
-- Conflict resolution procedures
-- Individual accountability measures
-
-## 📊 Data & Resources
-
-### Data Sources
-- **Public datasets**: Kaggle, UCI, HuggingFace datasets
-- **APIs**: Twitter, Reddit, news APIs (with proper permissions)
-- **Academic datasets**: Papers with code, shared task data
-- **Institutional data**: With proper permissions and anonymization
-
-### Computing Resources
-- **Personal laptops**: Suitable for prototyping and small experiments
-- **Google Colab**: Free GPU access with usage limits
-- **University HPC**: Available with instructor approval
-- **Cloud credits**: Limited AWS/GCP credits available for exceptional projects
-
-## ⚖️ Ethical Guidelines
-
-### Data Privacy
-- Use only publicly available or properly licensed data
-- Anonymize personal information appropriately
-- Consider consent and fair use principles
-- Document data sources and licensing
-
-### Algorithmic Fairness
-- Test for bias across different demographic groups
-- Consider fairness metrics in evaluation
-- Discuss potential societal impacts
-- Propose mitigation strategies for identified biases
-
-### Reproducibility
-- Share code and documentation
-- Use version control throughout development
-- Document random seeds and hyperparameters
-- Provide clear replication instructions
-
-## 🆘 Support & Resources
-
-### Office Hours
-- **Instructor**: By appointment for project guidance
-- **TAs**: Regular office hours for technical support
-
-### Project Mentoring
-- Optional mid-project check-ins with instructor
-- Peer review sessions for project feedback
-- Industry mentor connections (for exceptional projects)
-
-### Technical Resources
-- Course GitHub repository with example projects
-- NLP library documentation and tutorials
-- Research paper repositories (ACL Anthology, arXiv)
-- Computing resource documentation
-
-## 🌟 Example Projects from Previous Years
-
-*(Note: These are illustrative examples - actual project links would be provided)*
-
-1. **\"Detecting Financial Misinformation on Social Media\"**
-   - Multi-modal approach combining text and user features
-   - Dataset: 50K labeled tweets about stock market
-   - Novel attention mechanism for temporal patterns
-
-2. **\"Automated Clinical Note Summarization\"**
-   - Extractive + abstractive summarization pipeline  
-   - Dataset: De-identified hospital records
-   - ROUGE score improvement over baselines
-
-3. **\"Cross-lingual Code-switching Detection\"**
-   - BERT-based approach for Spanish-English text
-   - Dataset: Social media posts from bilingual communities
-   - Achieved state-of-the-art F1 score
-
-## 📞 Getting Help
-
-**Questions about**:
-- Project scope and feasibility → Instructor office hours
-- Technical implementation → TA office hours  
-- Data access and ethics → Email instructor
-- Team issues → Contact instructor privately
+**Worth**: 45% of your final grade
+**Team size**: 3 people (your startup). Groups of 2 or 4 only by special permission.
+**Duration**: All 12 weeks of the summer term.
 
 ---
 
-**Remember**: The goal is to demonstrate your mastery of NLP concepts through a substantial, well-executed project. Focus on doing something meaningful rather than overly ambitious!
+## The idea
+
+This summer your team is a startup. Over 12 weeks you will form a company, find a real problem worth solving, and ship a working NLP product that real people can use by demo day.
+
+You are not writing a term paper about a model. You are building and launching something. That single change reshapes how you work: you make decisions for a user instead of a grader, you ship in small weekly increments instead of one big deliverable, and you measure success by whether the product actually works for someone, not only by a benchmark number.
+
+It is still an NLP course. Your product must contain real NLP work that you build and evaluate: your own model, pipeline, or system, with a proper held-out evaluation and an honest error analysis. A thin wrapper around someone else's API is not a project.
+
+## How this differs from a normal course project
+
+| A normal project | Your startup |
+|---|---|
+| Delivers a report and code | Ships a working product a stranger can use |
+| Judged on rigor and metrics | Judged on whether it works for a real user and is technically sound |
+| One big deliverable at the end | Weekly build, measure, learn loop |
+| A group splitting tasks | A team with a name and clear roles |
+| Asks "is my method correct?" | Also asks "does anyone want this, and how do they get it?" |
+
+## What to think about beyond the code
+
+Technical excellence with no answer to "who wants this and how do they reach it" is a failed startup, even when the model is good. Keep a one-page lean canvas and revisit it every week. Be ready to answer:
+
+- **User and problem**: Who exactly is this for? What do they do today to cope, and why does that hurt? Why now?
+- **Alternatives and differentiation**: What already exists (other tools, a chatbot, a spreadsheet, nothing)? Why is yours better for this user specifically?
+- **Value proposition**: One sentence. "We help [user] do [job] better, faster, or cheaper than [alternative]."
+- **Distribution**: How would a real user ever find and start using this? A product nobody can reach has no fit.
+- **Cost and sustainability**: What does it cost to serve one user request (API calls, compute)? This shapes your architecture.
+- **North-star metric**: The one number that means "it is working" (for example task success rate, or weekly returning users), not just F1.
+- **Ethics, privacy, and safety**: Data licensing, personal data, bias, and what happens when the model is wrong. This is a graded NLP competency, not an afterthought.
+- **Biggest risk**: What single thing is most likely to kill this project, and what is the cheapest test to find out early?
+
+## Your team
+
+Three people. By the end of Week 1 you must:
+
+1. Form your team.
+2. Choose a company name.
+3. Create your GitHub repository and add all members.
+4. Assign roles.
+
+**Everyone is an engineer and writes code.** On top of that, each member owns one hat that they are accountable for:
+
+| Hat | Owns | Accountable for |
+|---|---|---|
+| Product lead | The user and the roadmap | Customer interviews, scope, the lean canvas, the pitch |
+| Engineering lead | The codebase and the repo | Architecture, code review, repo health, deployment |
+| Data and Evaluation lead | Data and the truth | Datasets and licensing, the evaluation harness, metrics, error analysis |
+
+Owning a hat does not mean doing all of that work alone. It means making sure that part of the company exists and is healthy. Groups of 2 combine Product and Data on one person; groups of 4 add a Design and UX lead.
+
+## How you work: GitHub
+
+Your repository is the record of your work, and your weekly assessment is based on what is actually in it.
+
+- Every member creates a GitHub account. Your team has one shared repository. Submit the URL in Week 1.
+- **Issues for everything**: every task, bug, or feature is an issue with a label, an assignee, and a milestone. No silent work.
+- **Project board**: maintain a board with columns Todo, In Progress, In Review, Done. The board is your status.
+- **Milestones map to course weeks** so progress is visible.
+- **Branch and pull request**: one branch per issue. A teammate reviews and approves the pull request before it merges. No direct pushes to main.
+- **Link your work**: reference the issue your commit or pull request closes (for example, `Closes #14`).
+- **Hygiene files**: a README that says what the product is and how to run it, a LICENSE, and an issue template.
+
+## The weekly rhythm
+
+Every week follows the same loop: build, put it in front of a user, learn, report. There are two parts.
+
+### 1. Standup (last 30 to 40 minutes of each lecture)
+
+Each team gives a 2 to 5 minute update. **Demo over slides.** Four beats, in order:
+
+1. What we shipped this week (show it live or a short screen capture).
+2. What we learned from users or metrics (one number or one user quote).
+3. Our biggest challenge or blocker.
+4. Next week's one goal.
+
+Rotate which member presents each week so everyone practices. "Shipped" means merged or deployed, not "almost done."
+
+### 2. Written weekly report
+
+Before each session, commit a report to your repository as `reports/weekNN.md`, using the template in [`reports/_TEMPLATE.md`](../reports/_TEMPLATE.md). Every claim must link to the issue, pull request, or commit that backs it. A claim with no linked evidence does not count.
+
+## Timeline
+
+| Week | Session | Project focus | Due that week |
+|---|---|---|---|
+| 1 | Jun 3 | Kickoff: form your startup | Team, company name, repo, roles |
+| 2 | Jun 10 | Discovery: interview real users, run a demand test (a landing page or sign-up test) | Lean canvas v1, problem validated |
+| 3 | Jun 17 | Scope the MVP, start building the core flow | MVP scope |
+| 4 | Jun 24 | Build the MVP, first task-success test with users | Working core flow |
+| 5 | Jul 1 | Iterate on user feedback | Weekly report |
+| 6 | Jul 8 | **Mid-semester demo**: working MVP, user evidence, pivot or persevere decision | Mid-semester checkpoint |
+| 7 | Jul 15 | Build, measure, learn | Weekly report |
+| 8 | Jul 22 | Deepen the NLP core, evaluate it properly | Weekly report |
+| 9 | Jul 29 | Iterate, improve the metric | Weekly report |
+| 10 | Aug 5 | Harden the product | Weekly report |
+| 11 | Aug 12 | Measure fit: run a "would you miss it" survey, check returning users; polish | PMF reading, weekly report |
+| 12 | Aug 19 | **Demo day**: live product, pitch, technical appendix | Final deliverables |
+
+Weeks 6 and 12 are presentation sessions, so they have no separate written weekly report.
+
+## How you are graded
+
+The final project is 45% of your course grade, split as follows.
+
+| Component | Share of course | Based on |
+|---|---|---|
+| Weekly reports (10 reports, 3% each) | 30% | What you shipped, what you validated, your metrics, and balanced contribution, all backed by evidence in your repository |
+| Mid-semester checkpoint (Week 6) | 5% | A working MVP, real user evidence, and a clear pivot or persevere decision |
+| Final product and demo day (Week 12) | 10% | A working product, real NLP depth, and the quality of your pitch |
+| **Total** | **45%** | |
+
+Weekly reports are assessed against the rubric below, based on the evidence in your repository (merged pull requests, issues, commits, and your deployed product), not on writing quality. A polished report with nothing shipped behind it scores low; a plain report backed by real work scores high.
+
+### Weekly report rubric
+
+Each weekly report is scored on these criteria:
+
+| Criterion | What earns full marks |
+|---|---|
+| Shipped | Something real merged or deployed this week, with linked pull requests or commits |
+| Validation | Concrete evidence of learning from users (an interview, usage data, or a task-success test), not an opinion |
+| Metrics | Your north-star metric tracked against last week |
+| Process and repo hygiene | Issues, board, and pull requests match what the report claims |
+| Contribution balance | Every member shows evidence of contribution |
+| Communication | Clear and honest about blockers, with a concrete next goal |
+
+### Mid-semester checkpoint rubric (Week 6)
+
+- A working MVP of the core flow that someone outside the team can use.
+- Evidence from real users (interviews or usage), not assumptions.
+- A clear, reasoned pivot or persevere decision based on that evidence.
+- A functioning team: roles active, repository healthy, contribution balanced.
+
+### Final and demo day rubric (Week 12)
+
+- **Product (does it work)**: a live, working product that a stranger can use for the core task.
+- **NLP depth**: your own model, pipeline, or system, with a held-out evaluation and an honest error analysis. Report your metric and where the system fails.
+- **Validation arc**: evidence of how the product changed in response to users across the term.
+- **Pitch**: a clear demo-day presentation (problem, who it is for, live demo, what you learned, what is next).
+- **Technical appendix**: a short write-up of your architecture, data, evaluation, and ethics considerations.
+
+## What "shipped" and "validated" mean
+
+- **Shipped**: merged to your main branch or deployed where a user can reach it. Not "written locally," not "almost done."
+- **Validated**: you put the work in front of a real user and measured the result. A landing-page sign-up, an interview insight, a task-success rate, or a returning user all count. Your own confidence does not.
+
+## Project ideas
+
+Strong projects address a real problem with real NLP. Some directions:
+
+- **Information extraction and analysis**: sentiment tracking, financial or legal document analysis, clinical note structuring.
+- **Generation and summarization**: report generation from data, factual summarization, documentation assistance.
+- **Question answering and search**: domain-specific question answering, semantic search over a specialized corpus, a support chatbot.
+- **Language understanding**: intent recognition, essay scoring, text simplification for accessibility.
+- **Multilingual**: cross-lingual retrieval, translation quality estimation, code-switching detection.
+
+Pick a problem where you can reach real users this summer. A narrow problem solved well beats a broad problem solved shallowly.
+
+## Data and resources
+
+- **Data sources**: public datasets (Kaggle, UCI, Hugging Face), APIs (with proper permissions), academic and shared-task datasets. Use only data you are licensed to use, and anonymize personal information.
+- **Computing**: personal laptops for prototyping, Google Colab for free GPU, university HPC with instructor approval.
+
+## Ethics
+
+- **Data privacy**: use publicly available or properly licensed data, anonymize personal information, and document your sources and licensing.
+- **Fairness**: test for bias across groups, discuss societal impact, and propose mitigations.
+- **Reproducibility**: version control everything, document seeds and hyperparameters, and write clear setup instructions.
+
+## Getting help
+
+- **Project scope and feasibility**: instructor office hours.
+- **Technical implementation**: TA office hours.
+- **Data access and ethics**: email the instructor.
+- **Team issues**: contact the instructor privately.
+
+---
+
+The goal is to ship something real that you are proud of, built the way a small team actually builds: in the open, week by week, for a user who is not you.

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,16 @@
+# Weekly Reports
+
+Each team commits one report here before every lecture, named `weekNN.md`
+(for example `week02.md`, `week03.md`).
+
+## How to use the template
+
+1. Copy [`_TEMPLATE.md`](_TEMPLATE.md) to `weekNN.md` for the current week.
+2. Fill in every section.
+3. Back every claim with a link to the issue, pull request, or commit that proves it.
+   A claim with no linked evidence does not count.
+4. Commit it to your repository before the session. Then give your 2 to 5 minute
+   standup using the same four beats: shipped, learned, blocker, next goal.
+
+See [`../project/guidelines.md`](../project/guidelines.md) for the full project
+description, timeline, and grading rubric.

--- a/reports/_TEMPLATE.md
+++ b/reports/_TEMPLATE.md
@@ -1,0 +1,44 @@
+---
+team: <your-company-name>
+week: <NN>
+date: <YYYY-MM-DD>
+repo: <your-repo-url>
+deploy_url: <live-product-url-or-leave-empty>
+members:
+  - name: <name>
+    github: <handle>
+    hat: Product | Engineering | Data&Eval
+  - name: <name>
+    github: <handle>
+    hat: Product | Engineering | Data&Eval
+  - name: <name>
+    github: <handle>
+    hat: Product | Engineering | Data&Eval
+north_star:
+  metric: <e.g. task success rate>
+  value: <this week>
+  previous: <last week>
+---
+
+## Shipped this week
+- <what is now merged or deployed>  (evidence: #12, PR #34)
+
+## User / validation learning
+- <what you learned + how you got it: an interview, usage data, a task test>
+
+## Metrics snapshot
+- <metric>: <value> (was <previous>)
+
+## Challenges / blockers
+- <what is hard, and what help you need>
+
+## Next week's goal
+- <the one thing>
+
+## Individual contributions
+- <name> (<hat>): <what they did>  (evidence: PR #34, #12)
+- <name> (<hat>): <what they did>  (evidence: ...)
+- <name> (<hat>): <what they did>  (evidence: ...)
+
+## Lean canvas changes (if any)
+- <what shifted this week: user, problem, value proposition, cost, or risk>


### PR DESCRIPTION
Reframes the final project so each team of 3 forms a named startup and ships a working NLP product over the 12-week summer term, with a weekly build, measure, learn loop.

## What changed

- Rewrote project/guidelines.md as the single student-facing project document: the startup framing, how it differs from a normal project, the non-technical dimensions to consider (lean canvas), second-hat team roles on top of everyone being an engineer, the GitHub workflow expectations, the weekly standup and written report rhythm, the full week-by-week timeline, and the grading breakdown with published rubrics.
- Grading split within the 45%: weekly reports 30, mid-semester checkpoint in Week 6 5, final product and demo day in Week 12 10. Weekly reports are assessed from evidence in each team repository (merged pull requests, issues, commits, deployed product), not from writing quality.
- Added reports/_TEMPLATE.md, the structured weekly report template teams copy each week, and reports/README.md explaining its use.
- Updated README and SYLLABUS to link to project/guidelines.md and reflect the startup framing.

## Notes

- guidelines.md is kept as a separate file; README and SYLLABUS link to it rather than duplicating it.
- The NLP rigor requirement is preserved: the final deliverable requires the team's own model, pipeline, or system with a held-out evaluation and error analysis, not a thin API wrapper.