### PR TITLE
Drop URL fields from weekly report and add repo visibility policy

### DIFF
--- a/project/guidelines.md
+++ b/project/guidelines.md
@@ -49,7 +49,7 @@ Owning a hat means making sure that part of the company is healthy, not doing al
 
 Your repository is the record of your work.
 
-- One shared repo per team. Submit the URL in Week 1.
+- One shared repo per team. Submit the URL in Week 1. It can be public or private; if private, add the instructor (`aaarrmiinnn`) as a collaborator.
 - Every task is an issue with a label, assignee, and milestone. Keep a board (Todo, In Progress, In Review, Done).
 - One branch per issue. A teammate reviews and approves each pull request before it merges. No direct pushes to main.
 - Link commits and pull requests to the issues they close.

--- a/reports/_TEMPLATE.md
+++ b/reports/_TEMPLATE.md
@@ -2,8 +2,6 @@
 team: <your-company-name>
 week: <NN>
 date: <YYYY-MM-DD>
-repo: <your-repo-url>
-deploy_url: <live-product-url-or-leave-empty>
 members:
   - name: <name>
     github: <handle>
@@ -21,7 +19,7 @@ north_star:
 ---
 
 ## Shipped this week
-- <what is now merged or deployed>  (evidence: #12, PR #34)
+- <what is now merged or deployed>  (evidence: #12, PR #34; link the live product if it is deployed)
 
 ## User / validation learning
 - <what you learned + how you got it: an interview, usage data, a task test>


### PR DESCRIPTION
Two small changes:

- Weekly report template: remove the repo and deploy_url fields. The report already lives in the team repo, so the repo URL is redundant; the live product link can be included in the Shipped evidence instead.
- Guidelines: a team repo can be public or private. If private, the team must add the instructor (aaarrmiinnn) as a collaborator.