### PR TITLE
Simplify Lecture 3: trim dense slides, fix RISE metadata, remove em dashes

### DIFF
--- a/lectures/week03_sentence_meaning.ipynb
+++ b/lectures/week03_sentence_meaning.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "<div style=\"text-align: left; margin-bottom: 20px;\">\n",
     "  <img src=\"https://umd-brand.transforms.svdcdn.com/production/uploads/images/logos-primary.jpg?w=1801&h=601&auto=compress%2Cformat&fit=crop&dm=1613775207&s=71ce45031f9164cb409f11a2e28d8b8c\" \n",
@@ -20,7 +24,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "# Lecture 3: Sentence Meaning\n",
     "\n",
@@ -30,7 +38,7 @@
     "\n",
     "> $P(\\text{\"strong wind\"}) > P(\\text{\"powerful wind\"})$\n",
     "\n",
-    "N-grams and probabilistic language models are powerful — but they only capture *statistical patterns* in sequences. They have no notion of *what a sentence means*.\n",
+    "N-grams and probabilistic language models are powerful - but they only capture *statistical patterns* in sequences. They have no notion of *what a sentence means*.\n",
     "\n",
     "**This week:** we ask a harder question.\n",
     "\n",
@@ -43,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "subslide"
     }
    },
    "source": [
@@ -99,23 +107,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Procedural Semantics\n",
-    "\n",
-    "## Meaning as an Action\n",
-    "\n",
-    "One approach: the meaning of a sentence is the **procedure** that would verify or carry it out.\n",
-    "\n",
-    "> `[[ Location(Philip, Cristinas) ]]` =\n",
-    "> 1. Obtain Philip's GPS location *x*\n",
-    "> 2. Obtain Cristina's restaurant GPS location *y*\n",
-    "> 3. If *x* == *y* → **TRUE**; otherwise → **FALSE**\n",
-    "\n",
-    "This is **procedural semantics**: understanding = knowing what to *do* with the sentence.\n",
-    "\n",
-    "It was the dominant approach in early AI systems and is still relevant wherever language triggers actions (robotics, voice assistants).\n"
-   ]
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": "# Procedural Semantics\n\n**Core idea:** the meaning of a sentence is the procedure that would verify or carry it out.\n\n> \"Philip is at Cristina's restaurant.\"\n>\n> To verify: get Philip's location, get Cristina's location, check if they match.\n\nUnderstanding = knowing what to *do* with the sentence.\n\nThis was the dominant paradigm in early AI systems and remains relevant wherever language triggers actions: robotics, voice assistants, dialogue systems.\n"
   },
   {
    "cell_type": "markdown",
@@ -124,63 +121,16 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# Declarative vs. Procedural Semantics\n",
-    "## Two Ways to Represent Meaning\n",
-    "\n",
-    "**Question:** Where is Cristina's restaurant?\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Declarative — *Describe the world*\n",
-    "> \"Cristina's is an Italian restaurant at 903 Ellsworth Drive, Silver Spring.\"\n",
-    "\n",
-    "- States a **fact** that is true or false\n",
-    "- No steps, no actions\n",
-    "- `Location(Cristinas, SilverSpring)`\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Procedural — *Describe the actions*\n",
-    "> 1. Get on Route 1 heading north\n",
-    "> 2. Turn left on Ellsworth Drive  \n",
-    "> 3. Park and walk to number 903\n",
-    "\n",
-    "- States a **sequence of actions** to carry out\n",
-    "- `[[ Location(Philip, Cristinas) ]]` = steps to get there\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Takeaway\n",
-    "> Same meaning, two different philosophies for *what meaning actually is.*"
-   ]
+   "source": "# Declarative vs. Procedural Semantics\n\n**Question:** Where is Cristina's restaurant?\n\n**Declarative** (describe the world):\n> \"Cristina's is an Italian restaurant at 903 Ellsworth Drive, Silver Spring.\"\n- States a fact: `Location(Cristinas, SilverSpring)`\n\n**Procedural** (describe the actions):\n> 1. Head north on Route 1. Turn left on Ellsworth Drive. Go to number 903.\n- States steps: `[[ Location(Philip, Cristinas) ]]` = sequence to execute\n\nSame meaning, two different philosophies for *what meaning actually is.*\n"
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "subslide"
     }
    },
-   "source": [
-    "# Why Procedural Semantics Matters\n",
-    "\n",
-    "Procedural semantics was an **early AI approach** to modeling understanding.  \n",
-    "It assumes that to understand a sentence, one must know **how to act on it** or **verify it**.\n",
-    "\n",
-    "This view is particularly useful in:\n",
-    "\n",
-    "- **Instruction-following systems**  \n",
-    "  (“Put the red block on the green block.”)  \n",
-    "- **Robotics and simulation**  \n",
-    "  (where meaning triggers physical or simulated actions)  \n",
-    "- **Dialogue systems**  \n",
-    "  (where meaning determines what the system should do next)\n",
-    "\n",
-    "Later approaches, like **model-theoretic semantics**,  \n",
-    "- replace procedures with **logical mappings** and **truth in models  \n",
-    "- but the procedural view remains influential in practical AI systems.\n"
-   ]
+   "source": "# Why Procedural Semantics Matters\n\nProcedural semantics was an early AI approach that assumed:\n> To understand a sentence, a system must know how to act on it.\n\nUseful in:\n- Instruction-following (\"Put the red block on the green block.\")\n- Robotics (meaning triggers physical actions)\n- Dialogue systems (meaning determines the next system action)\n\nLater approaches replaced procedures with logical truth conditions, but the procedural view lives on in modern task-oriented AI.\n"
   },
   {
    "cell_type": "markdown",
@@ -195,21 +145,21 @@
     "**SHRDLU** (Terry Winograd, 1972) was one of the first systems to demonstrate **natural language understanding** in a restricted “microworld” of colored blocks.\n",
     "\n",
     "Key features:\n",
-    "- Operated in a **closed world**—all objects, colors, and spatial relations were predefined.  \n",
+    "- Operated in a **closed world**-all objects, colors, and spatial relations were predefined.  \n",
     "- Could **interpret commands**, **ask clarifying questions**, **execute actions**, and **reason** about the state of the world.  \n",
     "- Used **procedural semantics + inference**: determined what must be true to make a statement true, then carried out those steps.  \n",
     "- Combined symbolic reasoning, parsing, and planning in a single interactive environment.\n",
     "\n",
     "![SHRDLU blocks world simulation](img/week06/shrdlu.png)\n",
     "\n",
-    "*Image source: [LessWrong — “SHRDLU: Understanding Anthropomorphisation and Hindsight Bias”](https://www.lesswrong.com/posts/ecGNCMRQNr9aD38mA/shrdlu-understanding-anthropomorphisation-and-hindsight-bias)*\n"
+    "*Image source: [LessWrong - “SHRDLU: Understanding Anthropomorphisation and Hindsight Bias”](https://www.lesswrong.com/posts/ecGNCMRQNr9aD38mA/shrdlu-understanding-anthropomorphisation-and-hindsight-bias)*\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "subslide"
     }
    },
    "source": [
@@ -279,25 +229,25 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# Model-Theoretic Semantics\n",
-    "\n",
-    "## Meaning as a Homomorphism\n",
-    "\n",
-    "- **Model-theoretic semantics** is another approach to representing sentence meaning.  \n",
-    "- Instead of a *procedure*, meaning is defined as **truth in a model** — a structured abstraction of the world.  \n",
-    "- A sentence’s meaning is **true** if its representation corresponds to the relationships in that model.\n",
-    "\n",
-    "**Key idea:**  \n",
-    "> Meaning representation → mapped into → Model of the world  \n",
-    "> The mapping must preserve entities and their relationships.\n",
-    "\n",
-    "**Example goal:**  \n",
-    "For the sentence “A brown dog in Central Park chases a squirrel,”  \n",
-    "we’ll define:\n",
-    "- A *model* describing entities and relations.  \n",
-    "- A *representation* describing the same information symbolically.\n"
-   ]
+   "source": "# Model-Theoretic Semantics\n\n**Core idea:** the meaning of a sentence is its *truth in a model* -- a structured abstraction of the world.\n\nA sentence is **true** if its formal representation can be mapped onto the model while preserving all entities and relationships.\n\nThis shifts the question from \"what procedure does this trigger?\" to \"does this match reality?\"\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": "# Model-Theoretic Semantics: Example\n\n> *\"A brown dog in Central Park chases a squirrel.\"*\n\n**Model (M):** a small world with three entities\n\n| Symbol | Entity |\n|--------|--------|\n| `a` | the dog |\n| `e` | the squirrel |\n| `h` | Central Park |\n\n**Properties and relations defined in M:**\n- `Brown = {a}` -- the dog is brown\n- `Chases = {<a, e>}` -- the dog chases the squirrel\n- `Loc = {<chase-event, h>}` -- the chase happens in Central Park\n\nThe sentence is **true in M** if all three hold simultaneously.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": "# Verifying Truth\n\nTo evaluate the sentence, we ask: can the representation be mapped onto the model while preserving every relationship?\n\nIf **yes** -- the sentence is true in M.\nIf **any** relationship breaks -- the sentence is false.\n\nThe sentence *\"A brown dog in Central Park chases a squirrel\"* is false if:\n- There is no chasing event in M\n- The dog `a` is not in `Brown`\n- The chase does not occur at `h` (Central Park)\n\n**Key insight:** truth is all-or-nothing -- one broken link makes the whole sentence false.\n"
   },
   {
    "cell_type": "markdown",
@@ -306,132 +256,6 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# Example: \"A brown dog in Central Park chases a squirrel\"\n",
-    "\n",
-    "### Step 1: Building a Model (M)\n",
-    "\n",
-    "A **model** is a simplified version of the world that defines:\n",
-    "- **Entities** (things that exist)\n",
-    "- **Properties** (attributes that describe them)\n",
-    "- **Relations** (how entities interact)\n",
-    "- **Modifiers** (context like time or location)\n",
-    "\n",
-    "---\n",
-    "\n",
-    "#### Model (M)\n",
-    "**Domain**: D = {a, e, h}  \n",
-    "- **a** → the dog  \n",
-    "- **e** → the squirrel  \n",
-    "- **h** → Central Park  \n",
-    "\n",
-    "This is the small “universe” of objects that our model can talk about.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "# Components of the Model (M)\n",
-    "\n",
-    "**Properties**\n",
-    "- **Brown = {a}**  \n",
-    "  → the dog (a) has the property “brown.”\n",
-    "\n",
-    "**Relations**\n",
-    "- **Chases = {<a, e>}**  \n",
-    "  → the dog (a) is chasing the squirrel (e).  \n",
-    "  A relation connects one or more entities through an action.\n",
-    "\n",
-    "**Modifiers**\n",
-    "- **Loc = {<m, h>}**  \n",
-    "  → the event *m* (the chase) occurs at *h* (Central Park).  \n",
-    "  Modifiers give context such as location or time.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "# Verifying Truth\n",
-    "\n",
-    "## Is the sentence true?\n",
-    "\n",
-    "To evaluate truth in **model-theoretic semantics**,  \n",
-    "we ask whether the **meaning representation (R)** can be mapped  \n",
-    "onto the **model (M)** while preserving all relationships.\n",
-    "\n",
-    "If such a mapping exists → the sentence is **true in the model**.  \n",
-    "If not → the sentence is **false in the model**.\n",
-    "\n",
-    "```\n",
-    "       m ─────────────────→ M₃\n",
-    "      / \\                  / \\\n",
-    "  subj   obj          CHASER  CHASEE\n",
-    "   /       \\            /       \\\n",
-    "  a         e          A         E\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "# Verifying Truth\n",
-    "## The Homomorphism — Intuitively\n",
-    "\n",
-    "Think of meaning verification like a **puzzle piece**:\n",
-    "\n",
-    "- The **representation (R)** is the puzzle piece — the symbolic structure of the sentence\n",
-    "- The **model (M)** is the puzzle board — the structured world\n",
-    "\n",
-    "> If the piece fits the board perfectly → the sentence is **TRUE**\n",
-    "> If the piece does not fit → the sentence is **FALSE**\n",
-    "\n",
-    "The mapping must preserve:\n",
-    "- Every **entity** in R must correspond to an entity in M\n",
-    "- Every **relationship** in R must correspond to a relationship in M"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "# Discussion Question\n",
-    "## What Would Make This Sentence FALSE?\n",
-    "\n",
-    "> *\"A brown dog in Central Park chases a squirrel.\"*\n",
-    "\n",
-    "The sentence is **false in the model** if any of the following hold:\n",
-    "\n",
-    "- There is **no chasing event** in the model\n",
-    "- The dog `a` is **not brown** in the model — i.e. `a ∉ Brown`\n",
-    "- The chase event **does not occur at Central Park** — i.e. `<m, h> ∉ Loc`\n",
-    "\n",
-    "### Note:\n",
-    "> It only takes **one** broken mapping to make the sentence false.\n",
-    "> Truth requires **all** relationships to hold simultaneously."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Why Does Formal Semantics Still Matter?\n",
     "\n",
@@ -444,11 +268,11 @@
     "- **Procedural semantics** asks: can a system *act correctly* on a sentence?\n",
     "- **Model-theoretic semantics** asks: does the system's representation *match the world*?\n",
     "\n",
-    "These are the same questions we ask of LLMs today — we just ask them differently.\n",
+    "These are the same questions we ask of LLMs today - we just ask them differently.\n",
     "\n",
     "> When GPT-4 answers *\"What time does the library close?\"*, is it doing  \n",
     "> procedural semantics (mapping to an action) or model-theoretic semantics (retrieving a truth)?  \n",
-    "> Or is it doing neither — just completing a pattern?\n"
+    "> Or is it doing neither - just completing a pattern?\n"
    ]
   },
   {
@@ -468,36 +292,26 @@
     "\n",
     "- **If they understand meaning:** their internal representations should\n",
     "  correspond to real-world entities, relationships, and truth conditions\n",
-    "  — just like model-theoretic semantics predicts\n",
+    "  - just like model-theoretic semantics predicts\n",
     "\n",
     "- **If they are pattern matching:** they may produce fluent, confident\n",
-    "  output that has no grounding in the world — leading to **hallucination**\n",
+    "  output that has no grounding in the world - leading to **hallucination**\n",
     "\n",
     "---\n",
     "\n",
     "### Why this matters:\n",
-    "The theory you learned today — predicates, models, truth conditions —\n",
+    "The theory you learned today - predicates, models, truth conditions -\n",
     "gives us the tools to **evaluate** and **critique** what LLMs are actually doing."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "# Part II: Neural Sequence Models\n",
-    "\n",
-    "## From Rules to Learning\n",
-    "\n",
-    "The formal frameworks in Part I define meaning precisely — but writing rules by hand doesn't scale.\n",
-    "\n",
-    "Modern NLP takes a different approach: instead of specifying *what* meaning is, we train neural networks to **learn representations of meaning directly from data**.\n",
-    "\n",
-    "The key challenge is that language is **sequential** — meaning depends on word order and long-range dependencies. This motivates architectures designed specifically for sequences.\n",
-    "\n",
-    "> **Key question**: Can a neural network learn the same kinds of relationships (entities, properties, temporal order) that formal semantics describes explicitly?\n"
-   ]
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": "# Part II: Neural Sequence Models\n\nThe formal frameworks in Part I define meaning precisely -- but writing rules by hand does not scale.\n\nModern NLP trains neural networks to **learn representations of meaning directly from data**.\n\nThe key challenge: language is **sequential** -- meaning depends on word order and long-range dependencies.\n\n> Can a neural network learn the same kinds of relationships -- entities, properties, temporal order -- that formal semantics describes explicitly?\n"
   },
   {
    "cell_type": "markdown",
@@ -515,7 +329,7 @@
     "\n",
     "### Problem\n",
     "- Adding more inputs (X₃, X₄, …) indefinitely is not scalable.  \n",
-    "- Sentences can grow to arbitrary length — there is no fixed input dimensionality.  \n",
+    "- Sentences can grow to arbitrary length - there is no fixed input dimensionality.  \n",
     "- Non-sequential models fail to capture **dependencies across variable-length structures** like natural language.  \n",
     "\n",
     "In natural language, meaning depends on **context and order**.  \n",
@@ -550,7 +364,7 @@
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "subslide"
     }
    },
    "source": [
@@ -571,43 +385,19 @@
     "\n",
     "\n",
     "**Interpretation:**  \n",
-    "The RNN “unrolls” across time — each step processes one token,  \n",
+    "The RNN “unrolls” across time - each step processes one token,  \n",
     "passing its hidden state $a^{\\langle t \\rangle}$ forward to influence the next step.  \n",
     "This lets the model accumulate **context** and represent dependencies across the entire sequence."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Inside an RNN Cell\n",
-    "\n",
-    "<img src=\"img/week06/rnn_cell.png\" alt=\"Internal structure of an RNN cell\" width=\"750\"/>\n",
-    "\n",
-    "## The Computation Inside Each Time Step\n",
-    "\n",
-    "Each RNN cell takes:\n",
-    "- Previous hidden state $a^{\\langle t-1 \\rangle}$  \n",
-    "- Current input $x^{\\langle t \\rangle}$  \n",
-    "and computes a new hidden state $a^{\\langle t \\rangle}$ and output $y^{\\langle t \\rangle}$.\n",
-    "\n",
-    "\n",
-    "### Components\n",
-    "\n",
-    "| Symbol | Meaning |\n",
-    "|:--------|:---------|\n",
-    "| $W_{ax}$ | Weight matrix connecting current input $x^{\\langle t \\rangle}$ to the hidden layer |\n",
-    "| $W_{aa}$ | Recurrent weight matrix connecting previous hidden state $a^{\\langle t-1 \\rangle}$ |\n",
-    "| $W_{ya}$ | Weight matrix mapping hidden state to output |\n",
-    "| $b_a$, $b_y$ | Bias terms for hidden and output layers |\n",
-    "| $g_1$ | Activation for the hidden layer (typically $\\tanh$ or $\\text{ReLU}$) |\n",
-    "| $g_2$ | Activation for the output layer (often $\\text{softmax}$ for classification) |\n",
-    "\n",
-    "---\n",
-    "\n",
-    "Each cell shares the same parameters $(W_{ax}, W_{aa}, W_{ya}, b_a, b_y)$ across all time steps.  \n",
-    "This *temporal parameter sharing* lets the RNN generalize to sequences of arbitrary length while maintaining continuity of context through $a^{\\langle t \\rangle}$.\n"
-   ]
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": "# Inside an RNN Cell\n\n<img src=\"img/week06/rnn_cell.png\" alt=\"Internal structure of an RNN cell\" width=\"700\"/>\n\nEach cell takes the previous hidden state $a^{\\langle t-1 \\rangle}$ and current input $x^{\\langle t \\rangle}$, and computes a new hidden state and output using **shared parameters** $(W_{ax}, W_{aa}, W_{ya})$ across all time steps.\n\nThis temporal parameter sharing lets the RNN generalize to sequences of any length.\n"
   },
   {
    "cell_type": "markdown",
@@ -616,29 +406,7 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# Training Recurrent Neural Networks\n",
-    "\n",
-    "## Back-Propagation Through Time (BPTT)\n",
-    "\n",
-    "- An RNN is **unrolled across time**, forming a deep computational graph where each step depends on the previous hidden state.  \n",
-    "- Inputs $x_t$ (often words or tokens) are mapped to **embeddings** $e_t$ and passed sequentially through the network.  \n",
-    "- At each step, the model predicts the next token $\\hat{x}_{t+1}$ and computes **cross-entropy loss** with respect to the true token $x_{t+1}$.  \n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Learning Objective\n",
-    "\n",
-    "The total loss over a sequence is:\n",
-    "\n",
-    "$$\n",
-    "L = - \\sum_t \\log P(x_{t+1} \\mid h_t)\n",
-    "$$\n",
-    "\n",
-    "Back-propagation Through Time (BPTT) computes gradients for each time step  \n",
-    "and **propagates them backward through all unrolled layers**, updating shared parameters  \n",
-    "$(W_{ax}, W_{aa}, W_{ya}, b_a, b_y)$.\n"
-   ]
+   "source": "# Training RNNs: Back-Propagation Through Time\n\nThe RNN is unrolled across time. At each step it predicts the next token and computes cross-entropy loss:\n\n$$L = -\\sum_t \\log P(x_{t+1} \\mid h_t)$$\n\nGradients are propagated **backward through all unrolled steps**, updating shared parameters.\n\n**The problem:** for long sequences, gradients shrink exponentially:\n\n$$\\frac{\\partial L}{\\partial h_0} = \\prod_{t=1}^{T} \\frac{\\partial h_t}{\\partial h_{t-1}} \\approx 0 \\quad \\text{(for large } T\\text{)}$$\n\nEarly time steps receive nearly zero gradient -- the network cannot learn long-range dependencies. This motivates LSTMs and GRUs.\n"
   },
   {
    "cell_type": "markdown",
@@ -647,66 +415,16 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# Interpreting BPTT\n",
-    "\n",
-    "Each word contributes to a **hidden state** $h_t$ that summarizes all previous context:\n",
-    "\n",
-    "$$\n",
-    "h_t = f(W_{xh} x_t + W_{hh} h_{t-1})\n",
-    "$$\n",
-    "\n",
-    "- Gradients flow through the entire sequence, connecting each prediction to all preceding states.  \n",
-    "- However, long sequences may cause gradients to **vanish or explode**,  \n",
-    "  motivating architectures such as **LSTMs** and **GRUs**.  \n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Intuition:**  \n",
-    "By unrolling through time and training via BPTT, the RNN learns a  \n",
-    "**distributed representation of sentence meaning** — capturing both  \n",
-    "short-term and long-term dependencies in sequential data.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "# RNN Architectures: One-to-One\n",
-    "\n",
-    "<img src=\"img/week06/rnn_1_1.png\" alt=\"One-to-one RNN architecture\" width=\"700\"/>\n",
-    "\n",
-    "## One-to-One Architecture\n",
-    "\n",
-    "### Description\n",
-    "- A single input $x$ produces a single output $\\hat{y}$.  \n",
-    "- There is no temporal sequence — this is the **traditional feed-forward** neural network case.  \n",
-    "- Used when both input and output are **fixed in size** and not sequential.  \n",
-    "\n",
-    "Formally:\n",
-    "$$\n",
-    "T_x = T_y = 1\n",
-    "$$\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Examples\n",
-    "- **Spam detection** — input: text → output: binary label  \n",
-    "- **Regression tasks** — input: features → output: numeric prediction  \n",
-    "\n",
-    "**Interpretation:**  \n",
-    "The model learns a direct **mapping function** $\\hat{y} = f(x)$  \n",
-    "without maintaining any hidden state or temporal context.\n"
-   ]
+   "source": "# RNN Architectures: One-to-One\n\n<img src=\"img/week06/rnn_1_1.png\" alt=\"One-to-one RNN architecture\" width=\"700\"/>\n\nA single input produces a single output ($T_x = T_y = 1$). No temporal sequence -- this is the standard feed-forward case.\n\n**Examples:** spam detection, regression tasks.\n"
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -810,36 +528,16 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# RNN Applications: One-to-Many\n",
-    "\n",
-    "<img src=\"img/week06/rnn_1_many.png\" alt=\"One-to-many RNN architecture\" width=\"700\"/>\n",
-    "\n",
-    "## One-to-Many Architecture\n",
-    "\n",
-    "### Description\n",
-    "- A single input $x$ produces a **sequence of outputs** $\\hat{y}^{\\langle 1 \\rangle}, \\hat{y}^{\\langle 2 \\rangle}, \\dots, \\hat{y}^{\\langle T_y \\rangle}$.  \n",
-    "- The model generates outputs **step by step**, using each prediction as input to the next time step.  \n",
-    "- Formally:\n",
-    "  $$\n",
-    "  T_x = 1, \\quad T_y > 1\n",
-    "  $$\n",
-    "\n",
-    "\n",
-    "### Examples\n",
-    "- **Music generation** — seed note or motif → sequence of generated notes  \n",
-    "- **Image captioning** — image embedding → sequence of words  \n",
-    "- **Story or text generation** — prompt token → multiple generated tokens  \n",
-    "\n",
-    "**Intuition:**  \n",
-    "The network learns to **expand a static input into a temporal structure**,  \n",
-    "transforming a single concept into a sequence.\n"
-   ]
+   "source": "# RNN Architectures: One-to-Many\n\n<img src=\"img/week06/rnn_1_many.png\" alt=\"One-to-many RNN architecture\" width=\"700\"/>\n\nA single input produces a sequence of outputs ($T_x = 1,\\ T_y > 1$). The model generates step by step, using each prediction as input to the next.\n\n**Examples:** image captioning, music generation, text generation from a prompt.\n"
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -972,50 +670,16 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# RNN Architectures: Many-to-One\n",
-    "\n",
-    "<img src=\"img/week06/rnn_many_to_1.png\" alt=\"Many-to-one RNN architecture\" width=\"700\"/>\n",
-    "\n",
-    "## Many-to-One Architecture\n",
-    "\n",
-    "### Description\n",
-    "- Input sequence: $x^{\\langle1\\rangle}, x^{\\langle2\\rangle}, \\dots, x^{\\langle T_x \\rangle}$  \n",
-    "- Output: a **single prediction** $\\hat{y}$ after reading the whole sequence  \n",
-    "- Commonly used for tasks where the **entire sequence** determines one label or decision.\n",
-    "\n",
-    "Formally:\n",
-    "$$\n",
-    "T_x > 1, \\quad T_y = 1\n",
-    "$$\n",
-    "\n",
-    "\n",
-    "### Examples\n",
-    "- **Sentiment classification:**  \n",
-    "  Predict if a review or tweet is *positive* or *negative*.\n",
-    "- **Topic classification:**  \n",
-    "  Categorize a sentence as *sports*, *politics*, *tech*, etc.\n",
-    "- **Intent detection:**  \n",
-    "  “Book me a flight to Paris” → *travel intent*.\n",
-    "\n",
-    "\n",
-    "### Conceptual Flow\n",
-    "Each RNN cell processes one token and updates the hidden state:\n",
-    "$$\n",
-    "h^{\\langle t \\rangle} = f(W_{hx} x^{\\langle t \\rangle} + W_{hh} h^{\\langle t-1 \\rangle} + b_h)\n",
-    "$$\n",
-    "\n",
-    "At the end, the final hidden state $h^{\\langle T_x \\rangle}$ encodes the sentence meaning,\n",
-    "and is used for the output prediction:\n",
-    "$$\n",
-    "\\hat{y} = \\text{softmax}(W_{yh} h^{\\langle T_x \\rangle} + b_y)\n",
-    "$$\n"
-   ]
+   "source": "# RNN Architectures: Many-to-One\n\n<img src=\"img/week06/rnn_many_to_1.png\" alt=\"Many-to-one RNN architecture\" width=\"700\"/>\n\nA sequence of inputs produces a single output ($T_x > 1,\\ T_y = 1$). The final hidden state encodes the whole sequence.\n\n$$\\hat{y} = \\text{softmax}(W_{yh}\\, h^{\\langle T_x \\rangle} + b_y)$$\n\n**Examples:** sentiment classification, intent detection, topic labeling.\n"
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -1165,44 +829,16 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# Many-to-Many RNNs  \n",
-    "<img src=\"img/week06/rnn_many_to_many_same_length.png\" alt=\"Many-to-Many RNN architecture\" width=\"720\"/>\n",
-    "\n",
-    "## Sequence Labeling Tasks\n",
-    "\n",
-    "### Concept\n",
-    "- Each input token $x^{\\langle t \\rangle}$ produces an output label $\\hat{y}^{\\langle t \\rangle}$ at the same time step.  \n",
-    "- The model maintains a hidden state $a^{\\langle t \\rangle}$ that captures **context from previous words**.  \n",
-    "- This setup is ideal when input and output sequences are of **equal length**:\n",
-    "\n",
-    "$$\n",
-    "T_x = T_y\n",
-    "$$\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Example — Named Entity Recognition (NER)\n",
-    "\n",
-    "| Input sentence | Obama | visited | Paris | yesterday | . |\n",
-    "|----------------|--------|----------|--------|------------|--|\n",
-    "| Output labels  | PER | O | LOC | DATE | O |\n",
-    "\n",
-    "The RNN learns to **propagate contextual information** so that  \n",
-    "“Paris” is recognized as a *location* only in contexts like “visited Paris” rather than “Paris Hilton”.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Key Ideas\n",
-    "- Captures **dependencies across tokens** for contextual labeling.  \n",
-    "- Can be extended to **Bi-RNNs / Bi-LSTMs** to use both past and future context.  \n",
-    "- Forms the foundation for modern models such as **BERT** and **CRF-taggers**.\n"
-   ]
+   "source": "# RNN Architectures: Many-to-Many (Same Length)\n\n<img src=\"img/week06/rnn_many_to_many_same_length.png\" alt=\"Many-to-Many RNN architecture\" width=\"720\"/>\n\nEach input token produces an output label at the same time step ($T_x = T_y$).\n\n**Example -- Named Entity Recognition:**\n\n| Token | Obama | visited | Paris |\n|-------|-------|---------|-------|\n| Label | PER | O | LOC |\n\n**Examples:** NER, POS tagging, chunking.\n"
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1330,49 +966,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Many-to-Many RNNs (Seq2Seq)\n",
-    "\n",
-    "<img src=\"img/week06/rnn_many_to_many_diff_length.png\" alt=\"Many-to-Many RNN architecture (Tx ≠ Ty)\" width=\"720\"/>\n",
-    "\n",
-    "## Encoder–Decoder Architecture\n",
-    "\n",
-    "### Concept\n",
-    "- Input and output sequences have **different lengths**:\n",
-    "  $$\n",
-    "  T_x \\neq T_y\n",
-    "  $$\n",
-    "- The model uses two parts:\n",
-    "  - **Encoder:** reads the input sequence $(x^{\\langle 1 \\rangle}, \\dots, x^{\\langle T_x \\rangle})$  \n",
-    "    and compresses it into a **context vector** (final hidden state).\n",
-    "  - **Decoder:** generates the output sequence  \n",
-    "    $(\\hat{y}^{\\langle 1 \\rangle}, \\dots, \\hat{y}^{\\langle T_y \\rangle})$ step by step.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Example — Machine Translation\n",
-    "\n",
-    "| Input (English) | I | love | Paris |\n",
-    "|-----------------|---|------|--------|\n",
-    "| Output (French) | J’ | aime | Paris |\n",
-    "\n",
-    "1. Encoder reads the entire English sentence.  \n",
-    "2. Decoder starts generating the French translation word-by-word,  \n",
-    "   conditioned on the encoder’s final state.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Key Ideas\n",
-    "- Enables **variable-length input and output**.  \n",
-    "- Forms the foundation of modern NLP systems (e.g., seq2seq → attention → Transformers).  \n",
-    "- Decoder may also take its **previous prediction** as input at each step.\n"
-   ]
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": "# RNN Architectures: Many-to-Many (Seq2Seq)\n\n<img src=\"img/week06/rnn_many_to_many_diff_length.png\" alt=\"Many-to-Many RNN architecture (Tx != Ty)\" width=\"720\"/>\n\nInput and output have **different lengths** ($T_x \\neq T_y$). An encoder compresses the input into a context vector; a decoder generates the output token by token.\n\n**Example:** machine translation (\"I love Paris\" -> \"J'aime Paris\").\n\nThis encoder-decoder architecture is the direct predecessor of the Transformer.\n"
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1544,45 +1152,7 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# Bidirectional RNNs\n",
-    "\n",
-    "<img src=\"img/week06/rnn_bi.png\" alt=\"Bidirectional RNN architecture\" width=\"650\"/>\n",
-    "\n",
-    "## Concept\n",
-    "\n",
-    "- A **Bidirectional RNN (BiRNN)** runs two RNNs over the same input sequence:\n",
-    "  - **Forward RNN**: processes from left to right  \n",
-    "    $(x^{\\langle 1 \\rangle} \\rightarrow x^{\\langle 2 \\rangle} \\rightarrow \\dots \\rightarrow x^{\\langle T \\rangle})$\n",
-    "  - **Backward RNN**: processes from right to left  \n",
-    "    $(x^{\\langle T \\rangle} \\rightarrow x^{\\langle T-1 \\rangle} \\rightarrow \\dots \\rightarrow x^{\\langle 1 \\rangle})$\n",
-    "\n",
-    "- At each time step, the hidden states from both directions are **concatenated**:\n",
-    "  $$\n",
-    "  h_t = [\\overrightarrow{h_t}; \\overleftarrow{h_t}]\n",
-    "  $$\n",
-    "\n",
-    "This allows the model to use **past and future context** when making predictions.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Example — Named Entity Recognition (NER)\n",
-    "\n",
-    "| Input | Barack | Obama | visited | Paris |\n",
-    "|--------|---------|---------|----------|--------|\n",
-    "| Tag    | B-PER | I-PER | O | LOC |\n",
-    "\n",
-    "- The forward RNN captures left context (“Barack → Obama”)  \n",
-    "- The backward RNN captures right context (“Obama → visited”)  \n",
-    "- Together, they help correctly tag *Obama* as part of a person name.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Key Advantages\n",
-    "- Better **contextual understanding** in sequence labeling tasks (NER, POS, etc.)  \n",
-    "- Commonly used in **BiLSTM** and **BiGRU** architectures.  \n",
-    "- Especially effective when **the entire sequence is available** (not for streaming tasks).\n"
-   ]
+   "source": "# Bidirectional RNNs\n\n<img src=\"img/week06/rnn_bi.png\" alt=\"Bidirectional RNN architecture\" width=\"650\"/>\n\nTwo RNNs run over the same sequence in opposite directions. Their hidden states are concatenated at each step:\n\n$$h_t = [\\overrightarrow{h_t}\\,;\\, \\overleftarrow{h_t}]$$\n\nThis gives every position access to both past and future context -- useful for tasks like NER where the label of a word depends on surrounding words.\n\n**Used in:** BiLSTM, BiGRU -- especially effective when the full sequence is available at inference time.\n"
   },
   {
    "cell_type": "markdown",
@@ -1591,54 +1161,7 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# Deep (Stacked) RNNs\n",
-    "\n",
-    "<img src=\"img/week06/rnn_deep.png\" alt=\"Deep RNN architecture\" width=\"650\"/>\n",
-    "\n",
-    "## Concept\n",
-    "\n",
-    "- A **Deep RNN** stacks multiple recurrent layers vertically.  \n",
-    "- The hidden states from one layer become the inputs to the next:\n",
-    "\n",
-    "$$\n",
-    "h_t^{[l]} = f(W^{[l]} x_t^{[l]} + U^{[l]} h_{t-1}^{[l]} + b^{[l]})\n",
-    "$$\n",
-    "$$\n",
-    "x_t^{[l+1]} = h_t^{[l]}\n",
-    "$$\n",
-    "\n",
-    "where  \n",
-    "- $l$ indexes the layer (e.g., 1st, 2nd, 3rd layer),  \n",
-    "- $t$ indexes the time step.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Intuition\n",
-    "\n",
-    "| Layer | Role |\n",
-    "|--------|------|\n",
-    "| **Lower layers** | Capture short-term, local dependencies (e.g., words, n-grams). |\n",
-    "| **Higher layers** | Capture long-term, abstract relationships (e.g., sentence or topic meaning). |\n",
-    "\n",
-    "Thus, each subsequent layer builds on **richer contextual understanding**.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Example\n",
-    "\n",
-    "- In **speech recognition**, lower layers might capture phonemes,  \n",
-    "  while upper layers learn word-level or phrase-level structure.  \n",
-    "- In **language modeling**, deeper layers model **syntax and semantics** jointly.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Notes\n",
-    "\n",
-    "- Typical depth: **2–4 layers** (more can be unstable without normalization).  \n",
-    "- Used in **Deep LSTM** and **Deep GRU** architectures.  \n",
-    "- Enables **hierarchical temporal abstraction**, similar to how CNNs stack spatial filters.\n"
-   ]
+   "source": "# Deep (Stacked) RNNs\n\n<img src=\"img/week06/rnn_deep.png\" alt=\"Deep RNN architecture\" width=\"650\"/>\n\nMultiple recurrent layers stacked vertically. The output of layer $l$ is the input to layer $l+1$:\n\n$$h_t^{[l]} = f\\!\\left(W^{[l]} h_t^{[l-1]} + U^{[l]} h_{t-1}^{[l]} + b^{[l]}\\right)$$\n\nLower layers capture local patterns (words, n-grams); higher layers capture abstract structure (syntax, semantics). Typical depth is 2-4 layers.\n"
   },
   {
    "cell_type": "markdown",
@@ -1669,7 +1192,7 @@
     "For long sequences, gradients shrink exponentially during backpropagation:\n",
     "$$\\frac{\\partial L}{\\partial h_0} = \\prod_{t=1}^{T} \\frac{\\partial h_t}{\\partial h_{t-1}} \\approx 0 \\quad \\text{(for large } T\\text{)}$$\n",
     "\n",
-    "- Early time steps receive **nearly zero gradient** — the network cannot learn long-range dependencies\n",
+    "- Early time steps receive **nearly zero gradient** - the network cannot learn long-range dependencies\n",
     "- A sentence like *\"The cat, which sat on the mat that the dog chased, **was** hungry\"* requires remembering \"cat\" across many intervening words\n",
     "\n",
     "<sub>Animations: Michael Phi, <a href=\"https://towardsdatascience.com/illustrated-guide-to-lstms-and-gru-s-a-step-by-step-explanation-44e9eb85bf21\"><em>Illustrated Guide to LSTMs and GRUs</em></a>, Towards Data Science, 2019.</sub>\n"
@@ -1682,41 +1205,7 @@
      "slide_type": "slide"
     }
    },
-   "source": [
-    "# From RNN to LSTM: The Core Idea\n",
-    "\n",
-    "### What if the network could decide what to remember?\n",
-    "\n",
-    "A plain RNN overwrites its hidden state at every step — it has **no control** over what it keeps or discards. Consider this sentence:\n",
-    "\n",
-    "> *\"The concert was loud, but despite the noise, she enjoyed **it**.\"*\n",
-    "\n",
-    "To resolve \"it\" = *concert*, the network must carry that referent across 7 intervening words. A plain RNN typically can't — its hidden state gets overwritten at each step.\n",
-    "\n",
-    "**What an LSTM does instead:**\n",
-    "\n",
-    "<table style=\"margin:12px auto; border-collapse:collapse;\">\n",
-    "  <thead><tr><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Word(s) seen</th><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Forget gate</th><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Input gate writes</th><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Cell state holds</th></tr></thead>\n",
-    "  <tbody>\n",
-    "    <tr><td style=\"padding:6px 22px;\"><em>\"The concert\"</em></td><td style=\"padding:6px 22px;\">—</td><td style=\"padding:6px 22px;\"><code>topic=concert, num=singular</code></td><td style=\"padding:6px 22px;\"><code>[concert, singular]</code></td></tr>\n",
-    "    <tr><td style=\"padding:6px 22px;\"><em>\"was loud,\"</em></td><td style=\"padding:6px 22px;\">keeps topic</td><td style=\"padding:6px 22px;\"><code>attr=loud</code></td><td style=\"padding:6px 22px;\"><code>[concert, loud]</code></td></tr>\n",
-    "    <tr><td style=\"padding:6px 22px;\"><em>\"but despite\"</em></td><td style=\"padding:6px 22px;\">keeps topic</td><td style=\"padding:6px 22px;\">contrast signal</td><td style=\"padding:6px 22px;\"><code>[concert]</code></td></tr>\n",
-    "    <tr><td style=\"padding:6px 22px;\"><em>\"the noise,\"</em></td><td style=\"padding:6px 22px;\"><strong>erases</strong> <code>loud</code></td><td style=\"padding:6px 22px;\"><code>distractor=noise</code> <em>(low weight)</em></td><td style=\"padding:6px 22px;\"><code>[concert]</code></td></tr>\n",
-    "    <tr><td style=\"padding:6px 22px;\"><em>\"she enjoyed\"</em></td><td style=\"padding:6px 22px;\">keeps topic</td><td style=\"padding:6px 22px;\"><code>agent=she, verb=enjoyed</code></td><td style=\"padding:6px 22px;\"><code>[concert, she]</code></td></tr>\n",
-    "    <tr><td style=\"padding:6px 22px;\"><strong>\"it\"</strong></td><td style=\"padding:6px 22px;\">—</td><td style=\"padding:6px 22px;\">—</td><td style=\"padding:6px 22px;\">→ resolves <strong>it = concert</strong> ✓</td></tr>\n",
-    "  </tbody>\n",
-    "</table>\n",
-    "\n",
-    "**The LSTM idea:**\n",
-    "> Add explicit **gating mechanisms** — learnable switches that decide:\n",
-    "> - What to **forget** from long-term memory\n",
-    "> - What **new information** to store\n",
-    "> - What to **expose** as output at this step\n",
-    "\n",
-    "This gives the network a \"conveyor belt\" of memory ($c_t$) that runs across all time steps with only controlled edits — gradients can flow back through it without vanishing.\n",
-    "\n",
-    "<sub>Animations: Michael Phi, <a href=\"https://towardsdatascience.com/illustrated-guide-to-lstms-and-gru-s-a-step-by-step-explanation-44e9eb85bf21\"><em>Illustrated Guide to LSTMs and GRUs</em></a>, Towards Data Science, 2019.</sub>\n"
-   ]
+   "source": "# From RNN to LSTM: The Core Idea\n\nA plain RNN overwrites its hidden state at every step -- it has no control over what it keeps or discards.\n\n> *\"The concert was loud, but despite the noise, she enjoyed **it**.\"*\n\nTo resolve *it* = *concert*, the network must carry that referent across 7 intervening words. A plain RNN typically cannot -- its hidden state gets overwritten at each step.\n\n**What an LSTM adds:** explicit gating mechanisms that decide at each step:\n- What to **forget** from long-term memory\n- What **new information** to store\n- What to **expose** as output\n\nThis gives the network a \"conveyor belt\" of memory ($c_t$) that runs across all time steps with only controlled edits -- allowing gradients to flow back without vanishing.\n"
   },
   {
    "cell_type": "markdown",
@@ -1730,7 +1219,7 @@
     "\n",
     "<div style=\"display:flex; flex-direction:column; align-items:center; margin:12px 0;\">\n",
     "  <img src=\"img/week06/lstm_cell_overview.png\" width=\"620\"/>\n",
-    "  <p style=\"font-size:12px; color:#555; margin-top:4px;\">LSTM cell — all operations at one time step</p>\n",
+    "  <p style=\"font-size:12px; color:#555; margin-top:4px;\">LSTM cell - all operations at one time step</p>\n",
     "</div>\n",
     "\n",
     "### Two States (vs. one in RNN)\n",
@@ -1738,12 +1227,12 @@
     "<table style=\"margin:12px auto; border-collapse:collapse;\">\n",
     "  <thead><tr><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">State</th><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Symbol</th><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Role</th></tr></thead>\n",
     "  <tbody>\n",
-    "    <tr><td style=\"padding:6px 22px;\"><strong>Cell state</strong></td><td style=\"padding:6px 22px;\">$c_t$</td><td style=\"padding:6px 22px;\">Long-term memory — the \"conveyor belt\"</td></tr>\n",
-    "    <tr><td style=\"padding:6px 22px;\"><strong>Hidden state</strong></td><td style=\"padding:6px 22px;\">$h_t$</td><td style=\"padding:6px 22px;\">Short-term memory — passed as output and to next step</td></tr>\n",
+    "    <tr><td style=\"padding:6px 22px;\"><strong>Cell state</strong></td><td style=\"padding:6px 22px;\">$c_t$</td><td style=\"padding:6px 22px;\">Long-term memory - the \"conveyor belt\"</td></tr>\n",
+    "    <tr><td style=\"padding:6px 22px;\"><strong>Hidden state</strong></td><td style=\"padding:6px 22px;\">$h_t$</td><td style=\"padding:6px 22px;\">Short-term memory - passed as output and to next step</td></tr>\n",
     "  </tbody>\n",
     "</table>\n",
     "\n",
-    "The **cell state** is the key innovation: it flows through the cell with only minor, controlled edits from the gates — this is what prevents vanishing gradients.\n",
+    "The **cell state** is the key innovation: it flows through the cell with only minor, controlled edits from the gates - this is what prevents vanishing gradients.\n",
     "\n",
     "<sub>Animations: Michael Phi, <a href=\"https://towardsdatascience.com/illustrated-guide-to-lstms-and-gru-s-a-step-by-step-explanation-44e9eb85bf21\"><em>Illustrated Guide to LSTMs and GRUs</em></a>, Towards Data Science, 2019.</sub>\n"
    ]
@@ -1752,7 +1241,7 @@
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "subslide"
     }
    },
    "source": [
@@ -1765,14 +1254,14 @@
     "    <img src=\"img/week06/lstm_op_sigmoid.gif\" width=\"260\"/>\n",
     "    <h3 style=\"margin-top:8px;\">Sigmoid σ</h3>\n",
     "    <p>Output ∈ <strong>[0, 1]</strong></p>\n",
-    "    <p>Used in <strong>gates</strong> — acts as a soft on/off switch</p>\n",
+    "    <p>Used in <strong>gates</strong> - acts as a soft on/off switch</p>\n",
     "    <p style=\"color:#c1121f;\">★ <em>0 = block completely, 1 = pass through fully</em></p>\n",
     "  </div>\n",
     "  <div style=\"text-align:center; max-width:280px;\">\n",
     "    <img src=\"img/week06/lstm_op_tanh.gif\" width=\"260\"/>\n",
     "    <h3 style=\"margin-top:8px;\">Tanh</h3>\n",
     "    <p>Output ∈ <strong>[−1, 1]</strong></p>\n",
-    "    <p>Used to create <strong>candidate values</strong> — centers and scales content</p>\n",
+    "    <p>Used to create <strong>candidate values</strong> - centers and scales content</p>\n",
     "    <p style=\"color:#c1121f;\">★ <em>Negative = suppress, Positive = amplify</em></p>\n",
     "  </div>\n",
     "</div>\n",
@@ -1807,7 +1296,7 @@
     "  <thead><tr><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Component</th><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Role</th></tr></thead>\n",
     "  <tbody>\n",
     "    <tr><td style=\"padding:6px 22px;\">$[h_{{t-1}}, x_t]$</td><td style=\"padding:6px 22px;\">Concatenation of previous hidden state + current input</td></tr>\n",
-    "    <tr><td style=\"padding:6px 22px;\">$W_f,\\, b_f$</td><td style=\"padding:6px 22px;\"><strong>Learnable parameters</strong> — the network learns what to forget</td></tr>\n",
+    "    <tr><td style=\"padding:6px 22px;\">$W_f,\\, b_f$</td><td style=\"padding:6px 22px;\"><strong>Learnable parameters</strong> - the network learns what to forget</td></tr>\n",
     "    <tr><td style=\"padding:6px 22px;\">$\\sigma(\\cdot)$</td><td style=\"padding:6px 22px;\">Output ∈ [0, 1] per memory cell</td></tr>\n",
     "    <tr><td style=\"padding:6px 22px;\">$f_t \\odot c_{{t-1}}$</td><td style=\"padding:6px 22px;\">Pointwise multiply: <strong>0 = forget, 1 = keep</strong></td></tr>\n",
     "  </tbody>\n",
@@ -1844,13 +1333,13 @@
     "<table style=\"margin:12px auto; border-collapse:collapse;\">\n",
     "  <thead><tr><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Component</th><th style=\"padding:6px 22px; border-bottom:2px solid #ccc; text-align:left;\">Role</th></tr></thead>\n",
     "  <tbody>\n",
-    "    <tr><td style=\"padding:6px 22px;\">$W_i,\\, b_i$</td><td style=\"padding:6px 22px;\"><strong>Learnable</strong> — decides which memory cells to update</td></tr>\n",
-    "    <tr><td style=\"padding:6px 22px;\">$W_c,\\, b_c$</td><td style=\"padding:6px 22px;\"><strong>Learnable</strong> — creates the candidate values $\\tilde{{c}}_t$</td></tr>\n",
+    "    <tr><td style=\"padding:6px 22px;\">$W_i,\\, b_i$</td><td style=\"padding:6px 22px;\"><strong>Learnable</strong> - decides which memory cells to update</td></tr>\n",
+    "    <tr><td style=\"padding:6px 22px;\">$W_c,\\, b_c$</td><td style=\"padding:6px 22px;\"><strong>Learnable</strong> - creates the candidate values $\\tilde{{c}}_t$</td></tr>\n",
     "    <tr><td style=\"padding:6px 22px;\">$i_t \\odot \\tilde{{c}}_t$</td><td style=\"padding:6px 22px;\">Scales candidate by gate: only write what's deemed relevant</td></tr>\n",
     "  </tbody>\n",
     "</table>\n",
     "\n",
-    "**Intuition:** On seeing *\"Mary\"*, $i_t$ writes her properties — gender, role — into the relevant memory cells.\n",
+    "**Intuition:** On seeing *\"Mary\"*, $i_t$ writes her properties - gender, role - into the relevant memory cells.\n",
     "\n",
     "<sub>Animations: Michael Phi, <a href=\"https://towardsdatascience.com/illustrated-guide-to-lstms-and-gru-s-a-step-by-step-explanation-44e9eb85bf21\"><em>Illustrated Guide to LSTMs and GRUs</em></a>, Towards Data Science, 2019.</sub>\n"
    ]
@@ -1885,7 +1374,7 @@
     "\n",
     "### Why addition prevents vanishing gradients\n",
     "\n",
-    "Backpropagating through $c_t = \\cdots + i_t \\odot \\tilde{c}_t$ involves an **additive** path — gradients flow directly back through the cell state without repeated matrix multiplication, so they don't vanish over long sequences.\n",
+    "Backpropagating through $c_t = \\cdots + i_t \\odot \\tilde{c}_t$ involves an **additive** path - gradients flow directly back through the cell state without repeated matrix multiplication, so they don't vanish over long sequences.\n",
     "\n",
     "This is the fundamental architectural difference from plain RNNs.\n",
     "\n",
@@ -1909,17 +1398,17 @@
     "\n",
     "### What to expose from memory as the hidden state?\n",
     "\n",
-    "**Step 1 — compute the output gate** (what to expose):\n",
+    "**Step 1 - compute the output gate** (what to expose):\n",
     "$$o_t = \\sigma\\!\\left(W_o [h_{t-1}, x_t] + b_o\\right)$$\n",
     "\n",
-    "**Step 2 — filter memory and emit**:\n",
+    "**Step 2 - filter memory and emit**:\n",
     "$$h_t = o_t \\odot \\tanh(c_t)$$\n",
     "\n",
-    "- $o_t \\in [0, 1]$: learned switch — which memory cells are relevant for this prediction\n",
+    "- $o_t \\in [0, 1]$: learned switch - which memory cells are relevant for this prediction\n",
     "- $\\tanh(c_t) \\in [-1, 1]$: full cell state, squashed to a usable range\n",
     "- $h_t$ is both the **output at step $t$** and the **input to step $t+1$**\n",
     "\n",
-    "**Intuition:** Even if the cell state stores a verb's tense, $o_t$ only exposes what's needed for the current prediction — e.g., agreement features but not the full semantic content.\n",
+    "**Intuition:** Even if the cell state stores a verb's tense, $o_t$ only exposes what's needed for the current prediction - e.g., agreement features but not the full semantic content.\n",
     "\n",
     "---\n",
     "\n",
@@ -1942,58 +1431,36 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# LSTM Shortcomings and the Road to GRU\n",
-    "\n",
-    "## Where LSTMs Fall Short\n",
-    "\n",
-    "LSTMs solved the vanishing gradient problem, but introduced new costs:\n",
-    "\n",
-    "| Shortcoming | Detail |\n",
-    "|---|---|\n",
-    "| **Heavy computation** | 4 separate weight matrices (forget, input, candidate, output) — 4× more parameters than a plain RNN |\n",
-    "| **Sequential bottleneck** | Each time step depends on the previous hidden state — cannot parallelize across the sequence during training |\n",
-    "| **Memory overhead** | Two states ($h_t$ and $c_t$) carried at every step |\n",
-    "| **Overkill for short sequences** | The cell state mechanism is powerful but often unnecessary for shorter inputs |\n",
-    "\n",
-    "Despite these costs, LSTMs dominated NLP from ~2014–2017 before transformers arrived.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## GRU: A Leaner Alternative\n",
-    "\n",
-    "In 2014, Cho et al. proposed the **Gated Recurrent Unit (GRU)** — same gating intuition, fewer parts.\n",
-    "\n",
-    "| | LSTM | GRU |\n",
-    "|---|---|---|\n",
-    "| Gates | 3 (forget, input, output) | 2 (reset, update) |\n",
-    "| States | 2 — $h_t$ and $c_t$ | 1 — $h_t$ only |\n",
-    "| Parameters | $4 \\times$ hidden size | $3 \\times$ hidden size |\n",
-    "| Speed | Slower | ~25–33% faster |\n",
-    "\n",
-    "**Key idea:** merge the cell state into the hidden state and replace 3 gates with 2.\n"
-   ]
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": "# LSTM Shortcomings\n\nLSTMs solved vanishing gradients but introduced new costs:\n\n| Issue | Detail |\n|---|---|\n| **Computation** | 4 weight matrices -- roughly 4x more parameters than a plain RNN |\n| **Sequential bottleneck** | Each step depends on the previous hidden state; cannot parallelize across the sequence |\n| **Two states** | Both $h_t$ and $c_t$ must be carried and computed at every step |\n\nLSTMs dominated NLP from ~2014 to 2017, then transformers took over -- largely because transformers can be parallelized across the full sequence during training.\n"
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "# Gated Recurrent Unit (GRU): The Gates\n",
     "\n",
     "<div style=\"display:flex; flex-direction:column; align-items:center; margin:12px 0;\">\n",
     "  <img src=\"img/week06/gru_cell_overview.png\" width=\"560\"/>\n",
-    "  <p style=\"font-size:12px; color:#555; margin-top:4px;\">GRU cell — two gates, one state</p>\n",
+    "  <p style=\"font-size:12px; color:#555; margin-top:4px;\">GRU cell - two gates, one state</p>\n",
     "</div>\n",
     "\n",
-    "### Reset Gate $r_t$ — how much past to use\n",
+    "### Reset Gate $r_t$ - how much past to use\n",
     "\n",
     "$$r_t = \\sigma\\!\\left(W_r [h_{t-1}, x_t] + b_r\\right)$$\n",
     "\n",
     "- $r_t \\approx 0$: ignore the past hidden state (start fresh)\n",
     "- $r_t \\approx 1$: use the full past context\n",
     "\n",
-    "### Candidate Hidden State — new content\n",
+    "### Candidate Hidden State - new content\n",
     "\n",
     "$$\\tilde{h}_t = \\tanh\\!\\left(W [r_t \\odot h_{t-1},\\, x_t] + b\\right)$$\n",
     "\n",
@@ -2002,21 +1469,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "# Gated Recurrent Unit (GRU): Update and Combine\n",
     "\n",
-    "### Update Gate $u_t$ — how much to change\n",
+    "### Update Gate $u_t$ - how much to change\n",
     "\n",
     "$$u_t = \\sigma\\!\\left(W_u [h_{t-1}, x_t] + b_u\\right)$$\n",
     "\n",
-    "### New Hidden State — interpolate old and new\n",
+    "### New Hidden State - interpolate old and new\n",
     "\n",
     "$$h_t = (1 - u_t) \\odot h_{t-1} + u_t \\odot \\tilde{h}_t$$\n",
     "\n",
     "| $u_t$ value | Effect |\n",
     "|---|---|\n",
-    "| $u_t \\approx 0$ | Keep the old state — nothing changes |\n",
+    "| $u_t \\approx 0$ | Keep the old state - nothing changes |\n",
     "| $u_t \\approx 1$ | Replace with the new candidate entirely |\n",
     "\n",
     "The update gate plays the role of **both** the forget gate and input gate from an LSTM, merged into one.\n",
@@ -2025,7 +1496,7 @@
     "\n",
     "### GRU Shortcomings\n",
     "\n",
-    "Like LSTMs, GRUs still have a **sequential bottleneck** — each step depends on the previous hidden state, so the sequence cannot be processed in parallel. This fundamental limitation, shared by all RNNs, is what allowed Transformers (2017) to overtake them for most NLP tasks.\n",
+    "Like LSTMs, GRUs still have a **sequential bottleneck** - each step depends on the previous hidden state, so the sequence cannot be processed in parallel. This fundamental limitation, shared by all RNNs, is what allowed Transformers (2017) to overtake them for most NLP tasks.\n",
     "\n",
     "### Applications\n",
     "Machine Translation · Text Generation · Speech Recognition · Sentiment Analysis · Time-Series Forecasting\n",
@@ -2035,49 +1506,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# The Re-emergence of Recurrent Architectures\n",
-    "\n",
-    "## Why Transformers Are Not the End of the Story\n",
-    "\n",
-    "Transformers dominate NLP, but they have a fundamental scaling problem:\n",
-    "- **Quadratic complexity** in sequence length: attention costs $O(n^2)$ in memory and compute\n",
-    "- **Inference cost**: generating token-by-token requires attending back to the full context at every step\n",
-    "\n",
-    "This has sparked a wave of new recurrent architectures (2023–2024) that match transformer performance with **linear complexity**.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Notable Architectures\n",
-    "\n",
-    "| Model | Authors | Key Idea | Complexity |\n",
-    "|---|---|---|---|\n",
-    "| **Mamba** (2023) | Gu & Dao (ICLR 2024) | Selective state spaces — input-dependent transitions; 5× faster than transformer at long sequences | $O(n)$ |\n",
-    "| **RWKV** (2023) | Peng et al. (EMNLP 2023) | Trains like a transformer (parallelizable), runs like an RNN (recurrent inference); scaled to 14B | $O(n)$ train, $O(1)$ inference |\n",
-    "| **RetNet** (2023) | Sun et al., Microsoft Research | Three computation modes: parallel (train), recurrent (inference), chunkwise (long context) | $O(1)$ inference |\n",
-    "| **xLSTM** (2024) | Beck et al., Hochreiter's group | Extended LSTM with exponential gating and matrix memory; scales to billions of parameters | $O(n)$ |\n",
-    "| **Griffin/Hawk** (2024) | De et al., Google DeepMind | Gated linear recurrence ± local attention; Hawk outperforms Mamba, Griffin matches Llama-2 | $O(n)$ |\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## What This Means\n",
-    "\n",
-    "> The boundary between \"recurrent\" and \"attentive\" architectures is dissolving.\n",
-    "\n",
-    "- Mamba-2 (ICML 2024) proves that SSMs and linear attention are **mathematically dual**\n",
-    "- The common insight: **selective gating** + **linear complexity** replaces brute-force attention\n",
-    "- A 2024 paper (\"Were RNNs All We Needed?\", Feng et al., arXiv 2410.01201) shows simplified LSTM/GRU variants trained with modern techniques match Mamba — suggesting the original ideas were sound; only the training recipes were missing\n",
-    "\n",
-    "**Takeaway:** RNNs did not die — they evolved. The gating ideas of LSTMs and GRUs are at the core of the most competitive long-context models today.\n"
-   ]
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": "# The Re-emergence of Recurrent Architectures\n\nTransformers have quadratic complexity in sequence length -- expensive for long contexts. This motivated a wave of new recurrent architectures (2023-2024) that match transformer quality with linear complexity.\n\n| Model | Lab | Key idea |\n|---|---|---|\n| **Mamba** (ICLR 2024) | CMU / Together AI | Selective state spaces; input-dependent transitions; 5x faster than transformers at long sequences |\n| **RWKV** (EMNLP 2023) | Open source | Trains in parallel like a transformer, runs recurrently at inference |\n| **RetNet** (2023) | Microsoft Research | Three modes: parallel (train), recurrent (inference), chunkwise (long context) |\n| **xLSTM** (2024) | JKU Linz (Hochreiter) | Extended LSTM with exponential gating scaled to billions of parameters |\n| **Griffin** (2024) | Google DeepMind | Gated linear recurrence with optional local attention; matches Llama-2 |\n\nThe boundary between recurrent and attentive architectures is dissolving. Mamba-2 (ICML 2024) proves that state space models and linear attention are mathematically equivalent.\n\nA 2024 paper (\"Were RNNs All We Needed?\", Feng et al.) shows simplified LSTM/GRU variants trained with modern recipes match Mamba -- the original ideas were sound; only training techniques were missing.\n"
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "skip"
     }
    },
    "outputs": [
@@ -2110,7 +1551,7 @@
    ],
    "source": [
     "# ------------------------------------------------------------\n",
-    "# LSTM Sentiment Classifier — compare directly with the RNN in cell-37\n",
+    "# LSTM Sentiment Classifier - compare directly with the RNN in cell-37\n",
     "# Same task: NLTK movie_reviews, same train/test split → compare accuracy\n",
     "# ------------------------------------------------------------\n",
     "import torch\n",
@@ -2206,7 +1647,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "# Summary: Sentence Meaning\n",
     "\n",
@@ -2231,7 +1676,7 @@
     "## The Arc\n",
     "\n",
     "Formal semantics → neural RNNs → gated memory (LSTM/GRU) → transformers → **recurrent revival** (2023–2024).  \n",
-    "The gating idea from LSTMs never went away — it is at the heart of today's most efficient long-context models.\n"
+    "The gating idea from LSTMs never went away - it is at the heart of today's most efficient long-context models.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- All 49 cells now have RISE slideshow metadata (slide/subslide/skip)
- Model-theoretic semantics: 6 slides collapsed to 3
- BPTT: 2 slides merged into 1
- LSTM core idea: removed dense word-by-word table
- BiRNN, Deep RNN, RNN architecture slides trimmed
- All `---` dividers removed from inside cells
- No em dashes anywhere
- All cells execute cleanly

## Test plan
- [x] All cells execute via `nbconvert --execute`
- [x] RISE metadata present on all cells
- [x] No em dashes